### PR TITLE
fs: sdcardfs: Recall lower_inode perms

### DIFF
--- a/fs/sdcardfs/inode.c
+++ b/fs/sdcardfs/inode.c
@@ -663,7 +663,7 @@ static int sdcardfs_permission(struct inode *inode, int mask)
 	 * So we just let they do the things.
 	 * If there are any security hole, just uncomment following if block.
 	 */
-#if 0
+
 	if (!err) {
 		/*
 		 * Permission check on lower_inode(=EXT4).
@@ -677,7 +677,7 @@ static int sdcardfs_permission(struct inode *inode, int mask)
 
 		REVERT_CRED();
 	}
-#endif
+
 	return err;
 
 }


### PR DESCRIPTION
[  627.999755] Unable to handle kernel NULL pointer dereference at virtual address 00000004
[  628.007537] pgd = db7cc000
[  628.009674] [00000004] *pgd=00000000
[  628.013336] Internal error: Oops: 5 [#1] PREEMPT SMP ARM
[  628.018432] Modules linked in:
[  628.021453] CPU: 0    Not tainted  (3.4.113-yuga-g8398276bc88 #1)
[  628.027557] PC is at sdcardfs_permission+0x8/0xf8
[  628.032287] LR is at inode_permission+0xb8/0xe8
Test #1